### PR TITLE
fixed calendar sans refresh

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,4 +21,7 @@ import "controllers"
 import "bootstrap"
 import { initFlatpickr } from "../plugins/flatpickr";
 
-initFlatpickr();
+
+document.addEventListener("turbolinks:load", () => {
+  initFlatpickr();
+});


### PR DESCRIPTION
Le calendar s'affiche de suite dans les forms de rentals, sans refresh